### PR TITLE
Add weather forecast and location search

### DIFF
--- a/gylt/package.json
+++ b/gylt/package.json
@@ -15,6 +15,7 @@
     "expo": "~54.0.6",
     "expo-crypto": "^15.0.7",
     "expo-local-authentication": "^17.0.7",
+    "expo-location": "^19.0.7",
     "expo-secure-store": "^15.0.7",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.0",

--- a/gylt/pnpm-lock.yaml
+++ b/gylt/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       expo-local-authentication:
         specifier: ^17.0.7
         version: 17.0.7(expo@54.0.6(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))
+      expo-location:
+        specifier: ^19.0.7
+        version: 19.0.7(expo@54.0.6(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))
       expo-secure-store:
         specifier: ^15.0.7
         version: 15.0.7(expo@54.0.6(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))
@@ -1421,6 +1424,11 @@ packages:
 
   expo-local-authentication@17.0.7:
     resolution: {integrity: sha512-yRWcgYn/OIwxEDEk7cM7tRjQSHaTp5hpKwzq+g9NmSMJ1etzUzt0yGzkDiOjObj3YqFo0ucyDJ8WfanLhZDtMw==}
+    peerDependencies:
+      expo: '*'
+
+  expo-location@19.0.7:
+    resolution: {integrity: sha512-YNkh4r9E6ECbPkBCAMG5A5yHDgS0pw+Rzyd0l2ZQlCtjkhlODB55nMCKr5CZnUI0mXTkaSm8CwfoCO8n2MpYfg==}
     peerDependencies:
       expo: '*'
 
@@ -4519,6 +4527,10 @@ snapshots:
     dependencies:
       expo: 54.0.6(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       invariant: 2.2.4
+
+  expo-location@19.0.7(expo@54.0.6(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)):
+    dependencies:
+      expo: 54.0.6(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
 
   expo-modules-autolinking@3.0.10:
     dependencies:

--- a/gylt/src/modules/weather/Weather.styles.ts
+++ b/gylt/src/modules/weather/Weather.styles.ts
@@ -2,6 +2,10 @@
 import { StyleSheet } from "react-native";
 
 export const styles = StyleSheet.create({
-  container: { flex: 1, padding: 16, gap: 8, justifyContent: "flex-start" },
-  title: { fontSize: 22, fontWeight: "600" },
+  container: { flex: 1, padding: 16, gap: 8 },
+  search: { marginBottom: 8 },
+  loading: { marginVertical: 8 },
+  currentCard: { marginBottom: 8 },
+  dayCard: { marginBottom: 8 },
+  radarContainer: { marginTop: 16, alignItems: "center" },
 });

--- a/gylt/src/modules/weather/Weather.tsx
+++ b/gylt/src/modules/weather/Weather.tsx
@@ -1,14 +1,100 @@
 // src/modules/weather/Weather.tsx
-import React from "react";
-import { View, Text } from "react-native";
-import { styles } from ".//Weather.styles";
+import React, { useEffect, useState } from "react";
+import { View, FlatList } from "react-native";
+import { Card, Searchbar, Text, ActivityIndicator } from "react-native-paper";
+import * as Location from "expo-location";
+import { styles } from "./Weather.styles";
+
+type ForecastDay = { date: string; tempMax: number; tempMin: number };
 
 export function WeatherScreen() {
-  // Später: echte Wetter-API, Standort etc.
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [current, setCurrent] = useState<{ temperature: number; windspeed: number } | null>(null);
+  const [forecast, setForecast] = useState<ForecastDay[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { status } = await Location.requestForegroundPermissionsAsync();
+        if (status !== "granted") return;
+        const loc = await Location.getCurrentPositionAsync({});
+        await fetchWeather(loc.coords.latitude, loc.coords.longitude);
+      } catch {
+        /* ignore */
+      }
+    })();
+  }, []);
+
+  async function fetchWeather(lat: number, lon: number) {
+    setLoading(true);
+    try {
+      const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true&daily=weathercode,temperature_2m_max,temperature_2m_min&timezone=auto`;
+      const res = await fetch(url);
+      const data = await res.json();
+      setCurrent(data.current_weather);
+      const days: ForecastDay[] = (data.daily?.time || []).map((t: string, i: number) => ({
+        date: t,
+        tempMax: data.daily.temperature_2m_max[i],
+        tempMin: data.daily.temperature_2m_min[i],
+      }));
+      setForecast(days);
+    } catch {
+      // ignore network errors for now
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSubmit() {
+    const q = query.trim();
+    if (!q) return;
+    try {
+      const geo = await fetch(`https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(q)}&count=1`);
+      const gj = await geo.json();
+      if (gj.results?.length) {
+        const { latitude, longitude } = gj.results[0];
+        await fetchWeather(latitude, longitude);
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Wetter</Text>
-      <Text>Hier kommt später die aktuelle Vorhersage hin.</Text>
+      <Searchbar
+        placeholder="Ort suchen"
+        value={query}
+        onChangeText={setQuery}
+        onSubmitEditing={handleSubmit}
+        style={styles.search}
+      />
+      {loading && <ActivityIndicator style={styles.loading} />}
+      {current && (
+        <Card style={styles.currentCard}>
+          <Card.Title title="Aktuelles Wetter" />
+          <Card.Content>
+            <Text>{`Temperatur: ${current.temperature}°C`}</Text>
+            <Text>{`Wind: ${current.windspeed} km/h`}</Text>
+          </Card.Content>
+        </Card>
+      )}
+      <FlatList
+        data={forecast}
+        keyExtractor={d => d.date}
+        renderItem={({ item }) => (
+          <Card style={styles.dayCard}>
+            <Card.Title title={new Date(item.date).toLocaleDateString()} />
+            <Card.Content>
+              <Text>{`Max: ${item.tempMax}°C  Min: ${item.tempMin}°C`}</Text>
+            </Card.Content>
+          </Card>
+        )}
+      />
+      <View style={styles.radarContainer}>
+        <Text>Regenradar noch nicht implementiert</Text>
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- add expo-location dependency
- implement weather screen with current location, search, and 7-day forecast
- placeholder for rain radar

## Testing
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm test` (no tests defined)


------
https://chatgpt.com/codex/tasks/task_e_68c56a37357c8327835d2ee80c43e7b4